### PR TITLE
fix: replace infinity default with infinityMaxUses for pubic invites

### DIFF
--- a/package/src/adapter.ts
+++ b/package/src/adapter.ts
@@ -38,8 +38,12 @@ export const getInviteAdapter = (
 			const expiresAt = getDate(payload.expiresIn, "sec");
 			const token = generateToken();
 			const now = options.getDate();
-			const newMaxUses =
-				invite.maxUses ?? options.defaultMaxUses ?? (isPrivate ? 1 : Infinity);
+			const hasExplicitMaxUses =
+				invite.maxUses !== undefined && invite.maxUses !== null;
+
+			const newMaxUses = invite.maxUses ?? options.defaultMaxUses;
+
+			const isUnlimited = !isPrivate && !hasExplicitMaxUses;
 
 			return baseAdapter.create<InviteTypeWithId>({
 				model: inviteTable,
@@ -48,7 +52,8 @@ export const getInviteAdapter = (
 					createdByUserId: user.id,
 					createdAt: now,
 					expiresAt,
-					maxUses: newMaxUses,
+					maxUses: isUnlimited ? 1 : (newMaxUses ?? 1),
+					infinityMaxUses: isUnlimited,
 					redirectToAfterUpgrade: payload.redirectToAfterUpgrade,
 					shareInviterName: payload.shareInviterName,
 					emails: normalizeEmails(invite.email),

--- a/package/src/adapter.ts
+++ b/package/src/adapter.ts
@@ -39,9 +39,10 @@ export const getInviteAdapter = (
 			const token = generateToken();
 			const now = options.getDate();
 
-			const newMaxUses = invite.maxUses ?? options.defaultMaxUses;
+			const maxUses = invite.maxUses ?? options.defaultMaxUses;
 
-			const isUnlimited = !isPrivate && newMaxUses == null;
+			const isUnlimited =
+				!isPrivate && (maxUses == null || maxUses === Infinity);
 
 			return baseAdapter.create<InviteTypeWithId>({
 				model: inviteTable,
@@ -50,7 +51,7 @@ export const getInviteAdapter = (
 					createdByUserId: user.id,
 					createdAt: now,
 					expiresAt,
-					maxUses: isUnlimited ? 1 : (newMaxUses ?? 1),
+					maxUses: isUnlimited ? 1 : (maxUses ?? 1),
 					infinityMaxUses: isUnlimited,
 					redirectToAfterUpgrade: payload.redirectToAfterUpgrade,
 					shareInviterName: payload.shareInviterName,

--- a/package/src/adapter.ts
+++ b/package/src/adapter.ts
@@ -38,12 +38,10 @@ export const getInviteAdapter = (
 			const expiresAt = getDate(payload.expiresIn, "sec");
 			const token = generateToken();
 			const now = options.getDate();
-			const hasExplicitMaxUses =
-				invite.maxUses !== undefined && invite.maxUses !== null;
 
 			const newMaxUses = invite.maxUses ?? options.defaultMaxUses;
 
-			const isUnlimited = !isPrivate && !hasExplicitMaxUses;
+			const isUnlimited = !isPrivate && newMaxUses == null;
 
 			return baseAdapter.create<InviteTypeWithId>({
 				model: inviteTable,

--- a/package/src/hooks.ts
+++ b/package/src/hooks.ts
@@ -79,7 +79,7 @@ export const invitesHooks = (options: NewInviteOptions) => {
 
 					const timesUsed = await adapter.countInvitationUses(invitation.id);
 
-					if (!(timesUsed < invitation.maxUses)) {
+					if (!invitation.infinityMaxUses && timesUsed >= invitation.maxUses) {
 						throw APIError.from(
 							"BAD_REQUEST",
 							ERROR_CODES.NO_USES_LEFT_FOR_INVITE,

--- a/package/src/routes/activate-invite.ts
+++ b/package/src/routes/activate-invite.ts
@@ -105,7 +105,8 @@ export const activateInviteLogic = async (
 
 	const timesUsed = await adapter.countInvitationUses(invitation.id);
 
-	if (!(timesUsed < invitation.maxUses)) {
+	// If the invite doesn't have infinity max uses and has been used the maximum number of times, return an error
+	if (!invitation.infinityMaxUses && timesUsed >= invitation.maxUses) {
 		throw APIError.from(
 			"BAD_REQUEST",
 			ERROR_CODES.INVITE_TOKEN_HAS_ALREADY_BEEN_USED,

--- a/package/src/schema.ts
+++ b/package/src/schema.ts
@@ -7,6 +7,7 @@ export const schema = {
 			createdAt: { type: "date" },
 			expiresAt: { type: "date", required: true },
 			maxUses: { type: "number", required: true },
+			infinityMaxUses: { type: "boolean", required: true, defaultValue: false },
 			createdByUserId: {
 				type: "string",
 				references: { model: "user", field: "id", onDelete: "set null" },

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -309,6 +309,7 @@ export type InviteType = {
 	createdAt: Date;
 	expiresAt: Date;
 	maxUses: number;
+	infinityMaxUses: boolean;
 	redirectToAfterUpgrade?: string;
 	shareInviterName: boolean;
 	/**

--- a/package/tests/invite.activate.test.ts
+++ b/package/tests/invite.activate.test.ts
@@ -794,7 +794,7 @@ test("test activateInvite with custom schema", async ({ createAuth }) => {
 	expect(newInvite).not.toBeNull();
 });
 
-test("test activateInvite with infinite maxUses", async ({ createAuth }) => {
+test("test activateInvite with infiniteMaxUses", async ({ createAuth }) => {
 	const { client, db, signInWithTestUser } = await createAuth({
 		pluginOptions: {
 			...defaultOptions,
@@ -829,7 +829,7 @@ test("test activateInvite with infinite maxUses", async ({ createAuth }) => {
 		throw new Error("Invite not found");
 	}
 
-	expect(invite.maxUses).toBe(Infinity);
+	expect(invite.infinityMaxUses).toBe(true);
 
 	const inviteId = invite.id;
 


### PR DESCRIPTION
Closes #23 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `Infinity` defaults for public invites with an explicit `infinityMaxUses` flag and updated checks to allow unlimited public invites correctly. This avoids storing `Infinity` and fixes false “no uses left” errors.

- **Bug Fixes**
  - Added `infinityMaxUses` to schema/types (default false); set true for public invites when `maxUses` is null or `Infinity`.
  - Adapter writes `maxUses = 1` for unlimited invites; enforce limits only when `!infinityMaxUses` with `timesUsed >= maxUses` in hooks and activation.
  - Updated tests to assert `infinityMaxUses` instead of `maxUses === Infinity`.

- **Migration**
  - Add boolean column `infinityMaxUses` (default false).
  - Backfill unlimited invites: set `infinityMaxUses = true` and `maxUses = 1`.
  - Update client logic from `maxUses === Infinity` to `infinityMaxUses`.

<sup>Written for commit 96b4449daa8dc1c360ddeb9c4c61333a0d944a4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

