### PR TITLE
docs: improve homepage with new background, title, and description

### DIFF
--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Banner } from "@/components/banner";
-import { GithubButton, GithubLogo } from "@/components/github-button";
-import { NpmButton } from "@/components/npm-button";
+import { GithubLogo } from "@/components/github-button";
+import { Terminal } from "@/components/terminal";
 
 export default function HomePage() {
 	return (
@@ -87,35 +87,19 @@ export default function HomePage() {
 					</div>
 
 					<div className="flex justify-center mt-7">
-						<div className="flex w-fit px-6 gap-9 py-4 rounded-[10px] border border-white/10 dark:bg-white/5 bg-black/5 shadow-[0_0_30px_#ffffff33] dark:shadow-[0_0_30px_#ffffff40]">
-							<code className="md:text-sm text-xs font-geist flex items-center gap-0.5">
-								<span className="select-none">
-									<span className="text-sky-500">git:</span>
-									<span className="text-red-400">(main)</span>
-									<span> &gt;</span>
-								</span>
-								<span className="dark:text-white text-black">
-									pnpm add
-									<span className="dark:text-fuchsia-300 text-fuchsia-800">
-										{" "}
-										better-invite
-									</span>
-								</span>
-							</code>
-							<div className="flex gap-2 items-center">
-								<NpmButton
-									packageName="better-invite"
-									label=""
-									noExternalIcon
-								/>
-								<GithubButton
-									username="better-invite"
-									repository="better-invite"
-									label=""
-									noExternalIcon
-								/>
-							</div>
-						</div>
+						<Terminal
+							segments={[
+								{
+									text: "pnpm add",
+									className: "text-neutral-600 dark:text-neutral-300",
+								},
+								{
+									text: "better-invite",
+									className:
+										"text-fuchsia-600 dark:text-fuchsia-300 font-semibold",
+								},
+							]}
+						/>
 					</div>
 				</div>
 			</div>

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,11 +1,12 @@
+import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Banner } from "@/components/banner";
-import { GithubButton } from "@/components/github-button";
+import { GithubButton, GithubLogo } from "@/components/github-button";
 import { NpmButton } from "@/components/npm-button";
 
 export default function HomePage() {
 	return (
-		<>
+		<div className="relative grow overflow-hidden">
 			<Banner
 				variant="rainbow"
 				id="better-invite"
@@ -37,61 +38,85 @@ export default function HomePage() {
 					Go see the blog →
 				</Link>
 			</Banner>
-			<div className="flex flex-col justify-center text-center flex-1">
-				<h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
-					Better Invite
-				</h1>
-				<p className="mt-4 text-base text-muted-foreground">
-					A small plugin for inviting users to your Better Auth app.
-				</p>
-				<div className="flex justify-center mt-7">
-					<div className="flex w-fit px-6 gap-9 py-4 rounded-[10px] border border-white/10 dark:bg-white/5 bg-black/5 shadow-[0_0_30px_#ffffff33] dark:shadow-[0_0_30px_#ffffff40]">
-						<code className="md:text-sm text-xs font-geist flex items-center gap-0.5">
-							<span className="select-none">
-								<span className="text-sky-500">git:</span>
-								<span className="text-red-400">(main)</span>
-								<span> &gt;</span>
-							</span>
-							<span className="dark:text-white text-black">
-								pnpm add
-								<span className="dark:text-fuchsia-300 text-fuchsia-800">
-									{" "}
-									better-invite
+			{/* Credits: https://github.com/better-auth-ui/better-auth-ui/blob/main/apps/docs/src/routes/index.tsx#L47 */}
+			<div className="absolute top-0 left-1/4 h-[500px] w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-sky-600/20 blur-[120px] dark:bg-sky-600/10" />
+			<div className="absolute right-0 top-1/3 h-[400px] w-[400px] translate-x-1/2 rounded-full bg-blue-500/15 blur-[100px] dark:bg-blue-500/5" />
+
+			<div className="absolute inset-0 bg-size-[20px_20px] bg-[radial-gradient(#d4d4d4_1px,transparent_1px)] dark:bg-[radial-gradient(#404040_1px,transparent_1px)] [mask-image:linear-gradient(to_bottom,black,transparent)]" />
+			<div className="relative z-10 flex flex-col items-center px-6 py-12 text-center sm:pt-24 lg:pt-32">
+				<div className="flex flex-col justify-center text-center flex-1">
+					<h1 className="max-w-4xl text-4xl font-bold sm:text-5xl lg:text-7xl">
+						Better{" "}
+						<span className="bg-linear-to-r from-sky-700 to-black bg-clip-text text-transparent dark:from-sky-500/80 dark:to-white">
+							Invite
+						</span>
+					</h1>
+					<p className="mt-6 max-w-2xl text-lg text-neutral-600 sm:text-xl dark:text-neutral-400">
+						A plugin for{" "}
+						<a
+							href="https://better-auth.com"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="font-medium text-black underline decoration-sky-600/50 underline-offset-4 transition-colors hover:text-sky-700 dark:text-white dark:hover:text-sky-500"
+						>
+							Better Auth
+						</a>{" "}
+						that adds an invitation system, allowing you to create, send, and
+						manage invites for user sign-ups or role upgrades.
+					</p>
+
+					<div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+						<Link
+							href="/docs"
+							className="group inline-flex items-center justify-center gap-2 rounded-xl bg-black px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-black dark:bg-white dark:text-black dark:hover:bg-neutral-100"
+						>
+							Get Started
+							<ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+						</Link>
+						<a
+							href="https://github.com/better-invite/better-invite"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center justify-center gap-2 rounded-xl border border-neutral-200 bg-white/80 px-6 py-3 text-sm font-semibold text-neutral-700 backdrop-blur-sm transition-all hover:border-neutral-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-900/80 dark:text-neutral-300 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
+						>
+							<GithubLogo className="h-4 w-4" />
+							Star on GitHub
+						</a>
+					</div>
+
+					<div className="flex justify-center mt-7">
+						<div className="flex w-fit px-6 gap-9 py-4 rounded-[10px] border border-white/10 dark:bg-white/5 bg-black/5 shadow-[0_0_30px_#ffffff33] dark:shadow-[0_0_30px_#ffffff40]">
+							<code className="md:text-sm text-xs font-geist flex items-center gap-0.5">
+								<span className="select-none">
+									<span className="text-sky-500">git:</span>
+									<span className="text-red-400">(main)</span>
+									<span> &gt;</span>
 								</span>
-							</span>
-						</code>
-						<div className="flex gap-2 items-center">
-							<NpmButton packageName="better-invite" label="" noExternalIcon />
-							<GithubButton
-								username="better-invite"
-								repository="better-invite"
-								label=""
-								noExternalIcon
-							/>
+								<span className="dark:text-white text-black">
+									pnpm add
+									<span className="dark:text-fuchsia-300 text-fuchsia-800">
+										{" "}
+										better-invite
+									</span>
+								</span>
+							</code>
+							<div className="flex gap-2 items-center">
+								<NpmButton
+									packageName="better-invite"
+									label=""
+									noExternalIcon
+								/>
+								<GithubButton
+									username="better-invite"
+									repository="better-invite"
+									label=""
+									noExternalIcon
+								/>
+							</div>
 						</div>
 					</div>
 				</div>
-				<div className="flex items-center justify-center gap-3 mt-7">
-					<Link
-						href="/docs"
-						className="inline-flex h-11 items-center justify-center rounded-xl bg-foreground px-5 text-md font-medium text-background shadow-sm transition hover:opacity-90"
-					>
-						Docs
-					</Link>
-					<Link
-						href="https://demo.better-invite.com"
-						className="inline-flex h-11 items-center justify-center rounded-xl border px-5 text-md font-medium shadow-sm transition hover:bg-muted"
-					>
-						Showcase
-					</Link>
-					<Link
-						href="https://patreon.better-invite.com"
-						className="inline-flex h-11 items-center justify-center rounded-xl border px-5 text-md font-medium shadow-sm transition hover:bg-muted"
-					>
-						Donate
-					</Link>
-				</div>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
 				variant="rainbow"
 				id="better-invite"
 				rainbowSpeed="7s"
-				className="flex-col relative z-0"
+				className="flex-col relative z-1"
 				rainbowColors={[
 					"rgba(20,20,20,0.95)",
 					"rgba(40,40,40,0.9)",
@@ -23,7 +23,9 @@ export default function HomePage() {
 					<span className="font-semibold">
 						Better Auth Invite Plugin is now called <b>Better Invite</b>!
 					</span>
-					<span className="text-zinc-400 hidden md:block">|</span>
+					<span className="text-zinc-600 dark:text-zinc-400 hidden md:block">
+						|
+					</span>
 					<Link
 						href="/blog/0-5"
 						className="font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 hidden dark:hover:text-blue-300 transition-colors md:block"

--- a/docs/src/components/banner.tsx
+++ b/docs/src/components/banner.tsx
@@ -66,7 +66,7 @@ export function Banner({
 			className={cn(
 				"sticky top-0 z-40 flex flex-row items-center justify-center px-4 text-center text-sm font-medium",
 				variant === "normal" && "bg-fd-secondary",
-				variant === "rainbow" && "bg-fd-background",
+				variant === "rainbow" && "bg-fd-background/50",
 				!open && "hidden",
 				props.className,
 			)}

--- a/docs/src/components/github-button.tsx
+++ b/docs/src/components/github-button.tsx
@@ -1,13 +1,19 @@
 import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { SquareArrowOutUpRight } from "lucide-react";
 import Link from "next/link";
+import type React from "react";
+import { cn } from "@/lib/cn";
 
-export const GithubLogo = () => (
+export const GithubLogo = ({
+	className,
+	...props
+}: React.SVGProps<SVGSVGElement>) => (
 	<svg
 		role="img"
 		viewBox="0 0 24 24"
 		xmlns="http://www.w3.org/2000/svg"
-		className="size-3.5"
+		className={cn("size-3.5", className)}
+		{...props}
 	>
 		<title>GitHub</title>
 		<path

--- a/docs/src/components/terminal.tsx
+++ b/docs/src/components/terminal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+type Segment = {
+	text: string;
+	className?: string;
+};
+
+type TerminalProps = {
+	segments: Segment[];
+	commandToCopy?: string;
+	showPrompt?: boolean;
+};
+
+export function Terminal({
+	segments,
+	commandToCopy,
+	showPrompt = true,
+}: TerminalProps) {
+	const [copied, setCopied] = useState(false);
+
+	const fullCommand = commandToCopy || segments.map((s) => s.text).join(" ");
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(fullCommand);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error("Copy failed", err);
+		}
+	};
+
+	return (
+		<div className="w-fit overflow-hidden rounded-lg border border-neutral-200/80 bg-neutral-50 shadow-lg dark:border-white/10 dark:bg-neutral-900">
+			{/* Header */}
+			<div className="flex items-center gap-2 border-b border-neutral-200/80 bg-neutral-100/80 px-4 py-2.5 dark:border-white/5 dark:bg-white/5">
+				<div className="flex gap-1.5">
+					<span className="h-3 w-3 rounded-full bg-red-400/80" />
+					<span className="h-3 w-3 rounded-full bg-yellow-400/80" />
+					<span className="h-3 w-3 rounded-full bg-green-400/80" />
+				</div>
+				<span className="ml-2 text-xs text-neutral-500">Terminal</span>
+			</div>
+
+			{/* Command */}
+			<button
+				type="button"
+				onClick={handleCopy}
+				className="group flex w-full items-center justify-between gap-6 px-5 py-4 hover:bg-neutral-100/60 dark:hover:bg-white/5 cursor-pointer"
+			>
+				<code className="flex items-center gap-1 font-mono text-xs md:text-sm">
+					{showPrompt && (
+						<>
+							<span className="select-none text-emerald-500">~</span>
+							<span className="select-none text-sky-500">$</span>
+						</>
+					)}
+
+					{segments.map((seg) => (
+						<span key={seg.text} className={seg.className}>
+							{seg.text}
+						</span>
+					))}
+				</code>
+
+				{copied ? (
+					<Check className="h-4 w-4 text-emerald-500" />
+				) : (
+					<Copy className="h-4 w-4" />
+				)}
+			</button>
+		</div>
+	);
+}


### PR DESCRIPTION
Heavily inspired by the Better Auth UI docs homepage: https://github.com/better-auth-ui/better-auth-ui/blob/main/apps/docs/src/routes/index.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamped the docs homepage with a new gradient/grid background and a clearer hero with updated CTAs. Added a copyable install `Terminal`, a GitHub star CTA, and customizable `GithubLogo`; also tweaked banner transparency and colors.

- **New Features**
  - Gradient blur orbs and dotted grid background with mask; updated hero with “Get Started” and “Star on GitHub” CTAs.
  - New copy-to-clipboard install `Terminal` for “pnpm add `better-invite`”; exported `GithubLogo` with `className` support (via `cn`) for flexible sizing/styling.

- **Bug Fixes**
  - Reduced rainbow banner opacity and fixed light/dark separator color for better contrast.

<sup>Written for commit e74587ebabdb80ceed3c7d098475b18980c2c45b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

