### PR TITLE
feat: prettier install command with copy-to-clipboard

### DIFF
--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Banner } from "@/components/banner";
-import { GithubButton, GithubLogo } from "@/components/github-button";
-import { NpmButton } from "@/components/npm-button";
+import { GithubLogo } from "@/components/github-button";
+import { InstallCommand } from "@/components/install-command";
 
 export default function HomePage() {
 	return (
@@ -87,35 +87,7 @@ export default function HomePage() {
 					</div>
 
 					<div className="flex justify-center mt-7">
-						<div className="flex w-fit px-6 gap-9 py-4 rounded-[10px] border border-white/10 dark:bg-white/5 bg-black/5 shadow-[0_0_30px_#ffffff33] dark:shadow-[0_0_30px_#ffffff40]">
-							<code className="md:text-sm text-xs font-geist flex items-center gap-0.5">
-								<span className="select-none">
-									<span className="text-sky-500">git:</span>
-									<span className="text-red-400">(main)</span>
-									<span> &gt;</span>
-								</span>
-								<span className="dark:text-white text-black">
-									pnpm add
-									<span className="dark:text-fuchsia-300 text-fuchsia-800">
-										{" "}
-										better-invite
-									</span>
-								</span>
-							</code>
-							<div className="flex gap-2 items-center">
-								<NpmButton
-									packageName="better-invite"
-									label=""
-									noExternalIcon
-								/>
-								<GithubButton
-									username="better-invite"
-									repository="better-invite"
-									label=""
-									noExternalIcon
-								/>
-							</div>
-						</div>
+						<InstallCommand />
 					</div>
 				</div>
 			</div>

--- a/docs/src/components/install-command.tsx
+++ b/docs/src/components/install-command.tsx
@@ -27,29 +27,49 @@ export function InstallCommand() {
 	};
 
 	return (
-		<button
-			type="button"
-			onClick={handleCopy}
-			aria-label="Copy install command to clipboard"
-			className="group flex w-fit items-center gap-3 rounded-xl border border-neutral-200/60 bg-neutral-50/80 px-5 py-3 shadow-sm backdrop-blur-sm transition-all hover:border-neutral-300 hover:bg-white hover:shadow-md dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20 dark:hover:bg-white/8 dark:shadow-[0_0_24px_#ffffff18] dark:hover:shadow-[0_0_32px_#ffffff28]"
-		>
-			<code className="flex items-center gap-1.5 font-mono text-xs md:text-sm">
-				<span className="select-none text-neutral-400 dark:text-neutral-500">
-					$
+		<div className="w-fit overflow-hidden rounded-lg border border-neutral-200/80 bg-neutral-50 shadow-lg dark:border-white/10 dark:bg-neutral-900 dark:shadow-[0_0_40px_#ffffff20]">
+			{/* Terminal header */}
+			<div className="flex items-center gap-2 border-b border-neutral-200/80 bg-neutral-100/80 px-4 py-2.5 dark:border-white/5 dark:bg-white/5">
+				<div className="flex gap-1.5">
+					<span className="h-3 w-3 rounded-full bg-red-400/80 dark:bg-red-500/70" />
+					<span className="h-3 w-3 rounded-full bg-yellow-400/80 dark:bg-yellow-500/70" />
+					<span className="h-3 w-3 rounded-full bg-green-400/80 dark:bg-green-500/70" />
+				</div>
+				<span className="ml-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+					Terminal
 				</span>
-				<span className="text-neutral-500 dark:text-neutral-400">pnpm add</span>
-				<span className="font-semibold text-fuchsia-700 dark:text-fuchsia-300">
-					better-invite
-				</span>
-			</code>
+			</div>
 
-			<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-white text-neutral-400 shadow-xs transition-all group-hover:border-neutral-300 group-hover:text-neutral-600 dark:border-white/10 dark:bg-white/5 dark:text-neutral-500 dark:group-hover:border-white/20 dark:group-hover:text-neutral-300">
-				{copied ? (
-					<Check className="h-3.5 w-3.5 text-emerald-500" />
-				) : (
-					<Copy className="h-3.5 w-3.5" />
-				)}
-			</span>
-		</button>
+			{/* Terminal body */}
+			<button
+				type="button"
+				onClick={handleCopy}
+				aria-label="Copy install command to clipboard"
+				className="group flex w-full items-center justify-between gap-6 px-5 py-4 transition-colors hover:bg-neutral-100/60 dark:hover:bg-white/5"
+			>
+				<code className="flex items-center gap-2 font-mono text-xs md:text-sm">
+					<span className="select-none text-emerald-600 dark:text-emerald-400">
+						~
+					</span>
+					<span className="select-none text-sky-600 dark:text-sky-400">
+						$
+					</span>
+					<span className="text-neutral-600 dark:text-neutral-300">
+						pnpm add
+					</span>
+					<span className="font-semibold text-fuchsia-600 dark:text-fuchsia-300">
+						better-invite
+					</span>
+				</code>
+
+				<span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-white text-neutral-400 shadow-sm transition-all group-hover:border-neutral-300 group-hover:text-neutral-600 dark:border-white/10 dark:bg-white/5 dark:text-neutral-500 dark:group-hover:border-white/20 dark:group-hover:text-neutral-300">
+					{copied ? (
+						<Check className="h-4 w-4 text-emerald-500" />
+					) : (
+						<Copy className="h-4 w-4" />
+					)}
+				</span>
+			</button>
+		</div>
 	);
 }

--- a/docs/src/components/install-command.tsx
+++ b/docs/src/components/install-command.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+const COMMAND = "pnpm add better-invite";
+
+export function InstallCommand() {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(COMMAND);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// fallback for older browsers
+			const el = document.createElement("textarea");
+			el.value = COMMAND;
+			document.body.appendChild(el);
+			el.select();
+			document.execCommand("copy");
+			document.body.removeChild(el);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			aria-label="Copy install command to clipboard"
+			className="group flex w-fit items-center gap-3 rounded-xl border border-neutral-200/60 bg-neutral-50/80 px-5 py-3 shadow-sm backdrop-blur-sm transition-all hover:border-neutral-300 hover:bg-white hover:shadow-md dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20 dark:hover:bg-white/8 dark:shadow-[0_0_24px_#ffffff18] dark:hover:shadow-[0_0_32px_#ffffff28]"
+		>
+			<code className="flex items-center gap-1.5 font-mono text-xs md:text-sm">
+				<span className="select-none text-neutral-400 dark:text-neutral-500">
+					$
+				</span>
+				<span className="text-neutral-500 dark:text-neutral-400">pnpm add</span>
+				<span className="font-semibold text-fuchsia-700 dark:text-fuchsia-300">
+					better-invite
+				</span>
+			</code>
+
+			<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-white text-neutral-400 shadow-xs transition-all group-hover:border-neutral-300 group-hover:text-neutral-600 dark:border-white/10 dark:bg-white/5 dark:text-neutral-500 dark:group-hover:border-white/20 dark:group-hover:text-neutral-300">
+				{copied ? (
+					<Check className="h-3.5 w-3.5 text-emerald-500" />
+				) : (
+					<Copy className="h-3.5 w-3.5" />
+				)}
+			</span>
+		</button>
+	);
+}


### PR DESCRIPTION
Replaces the old terminal-styled install command block with a clean, interactive `InstallCommand` client component.

### Changes
- **New** `docs/src/components/install-command.tsx` — a `"use client"` component that renders `pnpm add better-invite` as a clickable pill. On click, it copies the command to the clipboard and shows a checkmark confirmation for 2 seconds.
- **Updated** `docs/src/app/(home)/page.tsx` — swaps out the old `<code>` block + `NpmButton`/`GithubButton` row for the new `<InstallCommand />` component and removes the now-unused imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the old install snippet with a macOS-style, clickable `InstallCommand` on the home page. Users can copy `pnpm add better-invite` in one click and see a quick confirmation.

- **New Features**
  - macOS-style terminal header and a single clickable command line for better UX.
  - One-click copy via Clipboard API with textarea fallback and a 2s checkmark confirmation.

- **Refactors**
  - Swapped the old code block and `NpmButton`/`GithubButton` row for `InstallCommand`.
  - Removed unused imports on the home page.

<sup>Written for commit 1256cca54c78dd599c2d5fb28c9bc7295c33df70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

