### PR TITLE
fix: stop marking invites as used when they are infinite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
   A plugin for <a href="https://www.better-auth.com">Better Auth</a> that adds an invitation system, allowing you to create, send, and manage invites for user sign-ups or role upgrades.
   <br />
   <a href="https://www.better-invite.com"><strong>Learn More »</strong></a>
+  <br />
+  <br />
+  <a href="https://demo.better-invite.com">Demo</a>
+  ·
+  <a href="https://www.better-invite.com">Website</a>
+  ·
+  <a href="https://github.com/better-invite/better-invite/issues">Issues</a>
 </p>
 
 <p align="center">

--- a/package/src/routes/activate-invite.ts
+++ b/package/src/routes/activate-invite.ts
@@ -104,9 +104,10 @@ export const activateInviteLogic = async (
 	}
 
 	const timesUsed = await adapter.countInvitationUses(invitation.id);
+	const isFiniteInvite = !invitation.infinityMaxUses;
 
 	// If the invite doesn't have infinity max uses and has been used the maximum number of times, return an error
-	if (!invitation.infinityMaxUses && timesUsed >= invitation.maxUses) {
+	if (isFiniteInvite && timesUsed >= invitation.maxUses) {
 		throw APIError.from(
 			"BAD_REQUEST",
 			ERROR_CODES.INVITE_TOKEN_HAS_ALREADY_BEEN_USED,

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -148,7 +148,11 @@ export const consumeInvite = async ({
 
 	const usedAt = options.getDate();
 
-	const isLastUse = timesUsed === invitation.maxUses - 1;
+	const isFiniteInvite = !invitation.infinityMaxUses;
+
+	const isLastUse = isFiniteInvite
+		? timesUsed === invitation.maxUses - 1
+		: false;
 	const shouldCleanup = isLastUse && options.cleanupInvitesAfterMaxUses;
 	const shouldCreateInviteUse = !shouldCleanup;
 

--- a/package/tests/invite.activate.test.ts
+++ b/package/tests/invite.activate.test.ts
@@ -861,7 +861,11 @@ test("test activateInvite with infiniteMaxUses", async ({ createAuth }) => {
 
 	// It should still exist because maxUses is infinite
 	expect(inviteUses).toBe(1);
-	expect(newInvite).not.toBeNull();
+	expect(newInvite).toMatchObject({
+		token: tokenValue,
+		status: "pending",
+		infinityMaxUses: true,
+	});
 });
 
 test("activateInvite uses defaultRedirectAfterUpgrade", async ({


### PR DESCRIPTION
- Now invites only get marked as used if they have a maxUses value and are not infinite.
- Updated readme to add demo and issues links
- Update activate invite test with infinite max uses to check that status remains pending

Closes #32 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop marking infinite invites as used so they never hit max-use checks or cleanup. Adds a test to ensure status stays pending and updates the README with Demo and Issues links.

<sup>Written for commit 3d193fd8aefd1b1b4d14faa119874632be7c51f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

