### PR TITLE
refactor: simplify code and add comments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
 		"source.fixAll.biome": "explicit",
 		"source.organizeImports.biome": "explicit"
 	},
-	"typescript.tsdk": "node_modules\\typescript\\lib"
+	"js/ts.tsdk.path": "node_modules\\typescript\\lib"
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,6 +47,6 @@
 		"@types/react-dom": "^19.2.3",
 		"postcss": "^8.5.6",
 		"tailwindcss": "^4.1.18",
-		"typescript": "^5.9.3"
+		"typescript": "catalog:"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",
-		"lefthook": "^2.1.0"
+		"lefthook": "^2.1.0",
+		"typescript": "catalog:"
 	}
 }

--- a/package/package.json
+++ b/package/package.json
@@ -27,7 +27,8 @@
 	"scripts": {
 		"test": "vitest",
 		"coverage": "vitest run --coverage",
-		"build": "tsdown"
+		"build": "tsdown",
+		"typecheck": "tsc --project tsconfig.json"
 	},
 	"files": [
 		"dist"
@@ -61,7 +62,7 @@
 		"better-auth": "^1.6.2",
 		"better-sqlite3": "^12.6.0",
 		"tsdown": "^0.21.7",
-		"typescript": "^5.9.3",
+		"typescript": "catalog:",
 		"vitest": "^4.0.17"
 	},
 	"peerDependencies": {

--- a/package/src/constants.ts
+++ b/package/src/constants.ts
@@ -17,6 +17,7 @@ export const ERROR_CODES = defineErrorCodes({
 	ADMIN_PLUGIN_IS_NOT_SET_UP: "Admin plugin is not set-up",
 	INVITATION_EMAIL_NOT_ENABLED: "Invitation email is not enabled",
 	INVITE_TOKEN_HAS_ALREADY_BEEN_USED: "Invite token has already been used",
+	INVITATION_NOT_CREATED: "Invitation could not be created",
 });
 
 export const Tokens: TokensType[] = ["token", "code", "custom"];

--- a/package/src/hooks.ts
+++ b/package/src/hooks.ts
@@ -12,64 +12,53 @@ export const invitesHooks = (options: NewInviteOptions) => {
 	return {
 		after: [
 			{
+				// Run this after sign in/up and callback endpoints to check for invite tokens
 				matcher: (context: HookEndpointContext) =>
 					context.path === "/sign-up/email" ||
 					context.path === "/sign-in/email" ||
 					context.path === "/sign-in/email-otp" ||
-					// For social logins, newSession is not available at the end of the initial /sign-in call
 					context.path === "/callback/:id" ||
 					context.path === "/verify-email",
 
 				handler: createAuthMiddleware(async (ctx) => {
+					// Make sure we have a new session with a user
 					const validation = z
 						.object({
 							user: z.object({ id: z.string() }),
 						})
 						.safeParse(ctx.context.newSession);
 
-					if (!validation.success) {
-						return;
-					}
+					if (!validation.success) return;
 
-					const {
-						user: { id: userId },
-					} = validation.data;
+					const userId = validation.data.user.id;
 
+					// Load the full user
 					let invitedUser = (await ctx.context.internalAdapter.findUserById(
 						userId,
 					)) as UserWithRole | null;
 
-					if (!invitedUser) {
-						return;
-					}
+					if (!invitedUser) return;
 
-					// Get cookie name (customizable)
-					const maxAge = options.inviteCookieMaxAge ?? 10 * 60; // 10 minutes
+					// Read the invite token from the cookie
+					const maxAge = options.inviteCookieMaxAge ?? 10 * 60;
 					const inviteCookie = ctx.context.createAuthCookie(
 						INVITE_COOKIE_NAME,
-						{
-							maxAge,
-						},
+						{ maxAge },
 					);
 
-					// const inviteToken = ctx.getCookie(cookie);
 					const inviteToken = await ctx.getSignedCookie(
 						inviteCookie.name,
 						ctx.context.secret,
 					);
 
-					if (!inviteToken) {
-						return;
-					}
+					if (!inviteToken) return;
 
 					const adapter = getInviteAdapter(ctx.context, options);
 
 					const invitation = await adapter.findInvitation(inviteToken);
+					if (!invitation) return;
 
-					if (invitation === null) {
-						return;
-					}
-
+					// Validate invite expiration
 					if (invitation.expiresAt < options.getDate()) {
 						throw APIError.from(
 							"BAD_REQUEST",
@@ -79,6 +68,7 @@ export const invitesHooks = (options: NewInviteOptions) => {
 
 					const timesUsed = await adapter.countInvitationUses(invitation.id);
 
+					// Check if the invite was already fully used
 					if (!invitation.infinityMaxUses && timesUsed >= invitation.maxUses) {
 						throw APIError.from(
 							"BAD_REQUEST",
@@ -86,6 +76,7 @@ export const invitesHooks = (options: NewInviteOptions) => {
 						);
 					}
 
+					// Get active session
 					const session =
 						ctx.context.newSession?.session ?? ctx.context.session?.session;
 
@@ -96,40 +87,46 @@ export const invitesHooks = (options: NewInviteOptions) => {
 						});
 					}
 
+					// Optional hook before accepting the invite
 					const before = await options.inviteHooks?.beforeAcceptInvite?.({
 						ctx,
 						invitedUser,
 					});
-					if (before?.user) {
-						invitedUser = before.user;
-					}
 
+					if (before?.user) invitedUser = before.user;
+
+					// Consume the invite (update role, refresh session, etc)
 					await consumeInvite({
 						ctx,
 						invitation,
 						invitedUser,
-						options,
-						userId,
-						timesUsed,
-						token: inviteToken,
 						session,
-						newAccount: true,
+						options,
 						adapter,
+						meta: {
+							userId,
+							timesUsed,
+							token: inviteToken,
+							newAccount: true,
+						},
 					});
 
-					// delete the invite cookie
+					// Clean up cookie after successful use
 					expireCookie(ctx, inviteCookie);
 
+					// Optional hook after accepting
 					await options.inviteHooks?.afterAcceptInvite?.({
 						ctx,
 						invitation,
 						invitedUser,
 					});
 
+					// Redirect user after upgrading their role
 					const redirectURL = invitation.redirectToAfterUpgrade?.replace(
 						"{token}",
 						ctx.params.token,
 					);
+
 					return ctx.redirect(redirectError(ctx.context, redirectURL));
 				}),
 			},

--- a/package/src/routes/activate-invite.ts
+++ b/package/src/routes/activate-invite.ts
@@ -10,7 +10,7 @@ import * as z from "zod";
 import { getInviteAdapter } from "../adapter";
 import { ERROR_CODES, INVITE_COOKIE_NAME } from "../constants";
 import type { NewInviteOptions } from "../types";
-import { consumeInvite } from "../utils";
+import { consumeInvite, getMaxUses } from "../utils";
 
 export const activateInvite = (options: NewInviteOptions) => {
 	return createAuthEndpoint(
@@ -90,6 +90,13 @@ export const activateInvite = (options: NewInviteOptions) => {
 	);
 };
 
+/**
+ * Handles the invite activation flow.
+ *
+ * - Makes sure the invite is valid (exists, not expired, not overused)
+ * - If the user is logged in => consumes the invite
+ * - If not => stores the token and redirects to sign in/up
+ */
 export const activateInviteLogic = async (
 	options: NewInviteOptions,
 	ctx: GenericEndpointContext,
@@ -97,56 +104,62 @@ export const activateInviteLogic = async (
 ) => {
 	const adapter = getInviteAdapter(ctx.context, options);
 
+	// Find the invitation
 	const invitation = await adapter.findInvitation(body.token);
-
 	if (!invitation) {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_TOKEN);
 	}
 
+	const maxUses = getMaxUses(invitation);
 	const timesUsed = await adapter.countInvitationUses(invitation.id);
 
-	// If the invite doesn't have infinity max uses and has been used the maximum number of times, return an error
-	if (!invitation.infinityMaxUses && timesUsed >= invitation.maxUses) {
+	// Check if the invite was already fully used
+	if (timesUsed >= maxUses) {
 		throw APIError.from(
 			"BAD_REQUEST",
 			ERROR_CODES.INVITE_TOKEN_HAS_ALREADY_BEEN_USED,
 		);
 	}
 
+	// Check if the invite expired
 	if (options.getDate() > invitation.expiresAt) {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OR_EXPIRED_INVITE);
 	}
 
-	const sessionObject = await getSessionFromCtx(ctx);
-	const session = sessionObject?.session;
-	let invitedUser = sessionObject?.user as UserWithRole | null;
+	// Get current session and user
+	const sessionData = await getSessionFromCtx(ctx);
+	const session = sessionData?.session;
+	let user = sessionData?.user as UserWithRole | null;
 
-	if (invitedUser && session) {
+	// If the user is already logged in, accept the invite
+	if (user && session) {
 		const before = await options.inviteHooks?.beforeAcceptInvite?.({
 			ctx,
-			invitedUser,
+			invitedUser: user,
 		});
-		if (before?.user) {
-			invitedUser = before.user;
-		}
 
+		if (before?.user) user = before.user;
+
+		// Consume the invite (update role, refresh session, etc)
 		await consumeInvite({
 			ctx,
 			invitation,
-			invitedUser,
-			options,
-			userId: invitedUser.id,
-			timesUsed,
-			token: body.token,
+			invitedUser: user,
 			session,
-			newAccount: false,
+			options,
 			adapter,
+			meta: {
+				userId: user.id,
+				token: body.token,
+				timesUsed,
+				newAccount: false,
+			},
 		});
 
 		await options.inviteHooks?.afterAcceptInvite?.({
 			ctx,
 			invitation,
-			invitedUser,
+			invitedUser: user,
 		});
 
 		return ctx.json({
@@ -160,19 +173,16 @@ export const activateInviteLogic = async (
 		});
 	}
 
-	// If user doesn't already exist, we set a cookie and redirect them to the sign in/up page
+	// If not logged in, store the token and ask the user to sign in/up
+	const maxAge = options.inviteCookieMaxAge ?? 10 * 60;
 
-	// Get cookie name (customizable)
-	const maxAge = options.inviteCookieMaxAge ?? 10 * 60; // 10 minutes
-	const inviteCookie = ctx.context.createAuthCookie(INVITE_COOKIE_NAME, {
-		maxAge,
-	});
+	const cookie = ctx.context.createAuthCookie(INVITE_COOKIE_NAME, { maxAge });
 
 	await ctx.setSignedCookie(
-		inviteCookie.name,
+		cookie.name,
 		body.token,
 		ctx.context.secret,
-		inviteCookie.attributes,
+		cookie.attributes,
 	);
 
 	return ctx.json({

--- a/package/src/routes/create-invite.ts
+++ b/package/src/routes/create-invite.ts
@@ -195,6 +195,13 @@ export const createInvite = (options: NewInviteOptions) => {
 			// If the invite is public, we return the token
 			const invitation = invitations[0];
 
+			if (!invitation) {
+				throw APIError.from(
+					"INTERNAL_SERVER_ERROR",
+					ERROR_CODES.INVITATION_NOT_CREATED,
+				);
+			}
+
 			const redirectTo =
 				senderResponseRedirect === "signUp"
 					? redirectToSignUp

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -21,137 +21,96 @@ import type {
 	TokensType,
 } from "./types";
 
-export const resolveInviteOptions = (
-	opts: InviteOptions,
-): NewInviteOptions => ({
-	getDate: opts.getDate ?? (() => new Date()),
-	invitationTokenExpiresIn: opts.invitationTokenExpiresIn ?? 60 * 60,
-	defaultShareInviterName: opts.defaultShareInviterName ?? true,
-	defaultSenderResponse: opts.defaultSenderResponse ?? "token",
-	defaultSenderResponseRedirect: opts.defaultSenderResponseRedirect ?? "signUp",
-	defaultTokenType: opts.defaultTokenType ?? "token",
-	defaultRedirectToSignIn: opts.defaultRedirectToSignIn ?? "/auth/sign-in",
-	defaultRedirectToSignUp: opts.defaultRedirectToSignUp ?? "/auth/sign-up",
-	canCreateInvite: opts.canCreateInvite ?? true,
-	canAcceptInvite: opts.canAcceptInvite ?? true,
-	canCancelInvite: opts.canCancelInvite ?? true,
-	canRejectInvite: opts.canRejectInvite ?? true,
-	cleanupInvitesAfterMaxUses: opts.cleanupInvitesAfterMaxUses ?? false,
-	cleanupInvitesOnDecision: opts.cleanupInvitesOnDecision ?? false,
-	...opts,
-});
-
-export const resolveInvitePayload = (
-	body: CreateInvite,
-	options: NewInviteOptions,
-) => ({
-	tokenType: body.tokenType ?? options.defaultTokenType,
-	redirectToSignUp: body.redirectToSignUp ?? options.defaultRedirectToSignUp,
-	redirectToSignIn: body.redirectToSignIn ?? options.defaultRedirectToSignIn,
-	maxUses: body.maxUses ?? options.defaultMaxUses,
-	expiresIn: body.expiresIn ?? options.invitationTokenExpiresIn,
-	redirectToAfterUpgrade:
-		body.redirectToAfterUpgrade ?? options.defaultRedirectAfterUpgrade,
-	shareInviterName: body.shareInviterName ?? options.defaultShareInviterName,
-	senderResponse: body.senderResponse ?? options.defaultSenderResponse,
-	senderResponseRedirect:
-		body.senderResponseRedirect ?? options.defaultSenderResponseRedirect,
-	customInviteUrl: body.customInviteUrl ?? options.defaultCustomInviteUrl,
-});
-
-export const resolveTokenGenerator = (
-	tokenType: TokensType,
-	options: NewInviteOptions,
-): (() => string) => {
-	if (tokenType === "custom" && options.generateToken) {
-		return options.generateToken;
-	}
-
-	const tokenGenerators: Record<TokensType, () => string> = {
-		code: () => generateRandomString(6, "0-9", "A-Z"),
-		token: () => generateId(24),
-		custom: () => generateId(24), // secure fallback
+type ConsumeInviteParams = {
+	ctx: GenericEndpointContext;
+	invitation: InviteTypeWithId;
+	invitedUser: UserWithRole;
+	session: Session;
+	options: NewInviteOptions;
+	adapter: InviteAdapter;
+	meta: {
+		userId: string;
+		token: string;
+		timesUsed: number;
+		newAccount: boolean;
 	};
-
-	return tokenGenerators[tokenType];
 };
 
+/**
+ * Handles the full invite acceptance flow.
+ *
+ * Validates the invite, updates the user's role,
+ * refreshes the session, and manages invite usage.
+ * Also runs optional hooks if provided.
+ *
+ * Throws if the invite is invalid, expired,
+ * doesn't match the user, or can't be accepted.
+ */
 export const consumeInvite = async ({
 	ctx,
 	invitation,
 	invitedUser,
-	options,
-	userId,
-	timesUsed,
-	token,
 	session,
-	newAccount,
+	options,
 	adapter,
-}: {
-	ctx: GenericEndpointContext;
-	invitation: InviteTypeWithId;
-	invitedUser: UserWithRole;
-	options: NewInviteOptions;
-	userId: string;
-	timesUsed: number;
-	token: string;
-	session: Session;
-	newAccount: boolean;
-	adapter: InviteAdapter;
-}) => {
+	meta,
+}: ConsumeInviteParams) => {
+	const { userId, token, timesUsed, newAccount } = meta;
+
+	// Normalize emails and detect private invite
 	const emails = normalizeEmails<string[]>(
 		invitation.emails ?? invitation.email,
 		[],
 	);
 	const isPrivate = emails.length > 0;
 
+	// Validate email for private invites
 	if (isPrivate && !emails.includes(invitedUser.email)) {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_EMAIL);
 	}
 
-	if (invitation.status !== "pending" && invitation.status !== undefined) {
+	// Validate invitation status
+	if (invitation.status && invitation.status !== "pending") {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_TOKEN);
 	}
 
-	const canAcceptInviteOptions =
+	// Check permissions
+	const canAcceptRaw =
 		typeof options.canAcceptInvite === "function"
 			? await options.canAcceptInvite({ invitedUser, newAccount })
 			: options.canAcceptInvite;
-	const canAcceptInvite =
-		typeof canAcceptInviteOptions === "object"
-			? await exports.checkPermissions(ctx, canAcceptInviteOptions) // fix vitest errors with vi.spyOn (https://github.com/vitest-dev/vitest/issues/6551)
-			: canAcceptInviteOptions;
 
-	if (!canAcceptInvite) {
+	const canAccept =
+		typeof canAcceptRaw === "object"
+			? await exports.checkPermissions(ctx, canAcceptRaw) // fix vitest errors with vi.spyOn (https://github.com/vitest-dev/vitest/issues/6551)
+			: canAcceptRaw;
+
+	if (!canAccept) {
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.CANT_ACCEPT_INVITE);
 	}
 
+	// Update user role
 	await ctx.context.adapter.update({
 		model: "user",
 		where: [{ field: "id", value: userId }],
-		update: {
-			role: invitation.role,
-		},
+		update: { role: invitation.role },
 	});
 
-	const updatedUser = {
-		...invitedUser,
-		role: invitation.role,
-	};
-	/**
-	 * Update the session cookie with the new user data
-	 */
+	const updatedUser = { ...invitedUser, role: invitation.role };
+
+	// Update session with new role
 	await setSessionCookie(ctx, {
 		session,
 		user: updatedUser,
 	});
 
+	const maxUses = getMaxUses(invitation);
 	const usedAt = options.getDate();
-
-	const isLastUse = timesUsed === invitation.maxUses - 1;
+	const isLastUse = timesUsed === maxUses - 1;
 	const shouldCleanup = isLastUse && options.cleanupInvitesAfterMaxUses;
 	const shouldCreateInviteUse = !shouldCleanup;
 
+	// Handle invite lifecycle
 	if (shouldCleanup) {
 		await adapter.deleteInviteUses(invitation.id);
 		await adapter.deleteInvitation(token);
@@ -161,6 +120,7 @@ export const consumeInvite = async ({
 		await adapter.updateInvitation(invitation.id, "used");
 	}
 
+	// Track usage only if invite still active
 	if (shouldCreateInviteUse) {
 		await adapter.createInviteUse({
 			inviteId: invitation.id,
@@ -169,22 +129,41 @@ export const consumeInvite = async ({
 		});
 	}
 
+	// Fire optional hook
 	if (options.onInvitationUsed) {
-		// After all the logic, we run onInvitationUsed
 		try {
-			await Promise.resolve(
-				options.onInvitationUsed({
-					invitedUser,
-					newUser: updatedUser,
-					newAccount,
-				}),
-			);
+			await options.onInvitationUsed({
+				invitedUser,
+				newUser: updatedUser,
+				newAccount,
+			});
 		} catch (e) {
-			ctx.context.logger.error("Error sending the invitation email", e);
+			ctx.context.logger.error("Error in onInvitationUsed hook", e);
 		}
 	}
 };
 
+export function getMaxUses(invitation: InviteTypeWithId) {
+	return invitation.infinityMaxUses ? Infinity : invitation.maxUses;
+}
+
+/**
+ * Converts a single email string or an array of emails into a normalized array format.
+ *
+ * @returns An array of email strings or a default value if the input is undefined.
+ *
+ * @example
+ * normalizeEmails("test@example.com")
+ * // => ["test@example.com"]
+ *
+ * @example
+ * normalizeEmails(["a@test.com", "b@test.com"])
+ * // => ["a@test.com", "b@test.com"]
+ *
+ * @example
+ * normalizeEmails(undefined, [])
+ * // => []
+ */
 export function normalizeEmails<T = string[] | undefined>(
 	email: string | string[] | undefined = undefined,
 	undefinedVal: T = undefined as T,
@@ -295,4 +274,59 @@ export const createRedirectURL = ({
 	return customInviteUrl
 		.replace("{token}", invitation.token)
 		.replace("{callbackURL}", encodeURIComponent(callbackURL));
+};
+
+export const resolveInviteOptions = (
+	opts: InviteOptions,
+): NewInviteOptions => ({
+	getDate: opts.getDate ?? (() => new Date()),
+	invitationTokenExpiresIn: opts.invitationTokenExpiresIn ?? 60 * 60,
+	defaultShareInviterName: opts.defaultShareInviterName ?? true,
+	defaultSenderResponse: opts.defaultSenderResponse ?? "token",
+	defaultSenderResponseRedirect: opts.defaultSenderResponseRedirect ?? "signUp",
+	defaultTokenType: opts.defaultTokenType ?? "token",
+	defaultRedirectToSignIn: opts.defaultRedirectToSignIn ?? "/auth/sign-in",
+	defaultRedirectToSignUp: opts.defaultRedirectToSignUp ?? "/auth/sign-up",
+	canCreateInvite: opts.canCreateInvite ?? true,
+	canAcceptInvite: opts.canAcceptInvite ?? true,
+	canCancelInvite: opts.canCancelInvite ?? true,
+	canRejectInvite: opts.canRejectInvite ?? true,
+	cleanupInvitesAfterMaxUses: opts.cleanupInvitesAfterMaxUses ?? false,
+	cleanupInvitesOnDecision: opts.cleanupInvitesOnDecision ?? false,
+	...opts,
+});
+
+export const resolveInvitePayload = (
+	body: CreateInvite,
+	options: NewInviteOptions,
+) => ({
+	tokenType: body.tokenType ?? options.defaultTokenType,
+	redirectToSignUp: body.redirectToSignUp ?? options.defaultRedirectToSignUp,
+	redirectToSignIn: body.redirectToSignIn ?? options.defaultRedirectToSignIn,
+	maxUses: body.maxUses ?? options.defaultMaxUses,
+	expiresIn: body.expiresIn ?? options.invitationTokenExpiresIn,
+	redirectToAfterUpgrade:
+		body.redirectToAfterUpgrade ?? options.defaultRedirectAfterUpgrade,
+	shareInviterName: body.shareInviterName ?? options.defaultShareInviterName,
+	senderResponse: body.senderResponse ?? options.defaultSenderResponse,
+	senderResponseRedirect:
+		body.senderResponseRedirect ?? options.defaultSenderResponseRedirect,
+	customInviteUrl: body.customInviteUrl ?? options.defaultCustomInviteUrl,
+});
+
+export const resolveTokenGenerator = (
+	tokenType: TokensType,
+	options: NewInviteOptions,
+): (() => string) => {
+	if (tokenType === "custom" && options.generateToken) {
+		return options.generateToken;
+	}
+
+	const tokenGenerators: Record<TokensType, () => string> = {
+		code: () => generateRandomString(6, "0-9", "A-Z"),
+		token: () => generateId(24),
+		custom: () => generateId(24), // secure fallback
+	};
+
+	return tokenGenerators[tokenType];
 };

--- a/package/tests/invite.activate.test.ts
+++ b/package/tests/invite.activate.test.ts
@@ -861,7 +861,11 @@ test("test activateInvite with infiniteMaxUses", async ({ createAuth }) => {
 
 	// It should still exist because maxUses is infinite
 	expect(inviteUses).toBe(1);
-	expect(newInvite).not.toBeNull();
+	expect(newInvite).toMatchObject({
+		token: tokenValue,
+		status: "pending",
+		infinityMaxUses: true,
+	});
 });
 
 test("activateInvite uses defaultRedirectAfterUpgrade", async ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+
 importers:
 
   .:
@@ -14,6 +20,9 @@ importers:
       lefthook:
         specifier: ^2.1.0
         version: 2.1.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   demo:
     dependencies:
@@ -224,7 +233,7 @@ importers:
         specifier: ^4.1.18
         version: 4.2.2
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   package:
@@ -255,7 +264,7 @@ importers:
         specifier: ^0.21.7
         version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.1)(typescript@5.9.3)
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
         specifier: ^4.0.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,6 @@ packages:
   - package
   - docs
   - demo
+
+catalog:
+  typescript: ^5.9.3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the invite activation flow with clearer control flow, stronger validation, and comments; fixed the infinite-invite edge case so tokens remain reusable. Standardized the workspace on a shared `typescript` catalog and added a `typecheck` script.

- **Refactors**
  - Simplified post-auth hooks: early returns; read signed cookie; validate invite (exists, expiry, max-uses); get session; optional before/after hooks; consume; expire cookie; redirect.
  - Reworked `consumeInvite`: single `meta` params; validates private emails and permissions; updates role and session; tracks usage; cleans up on last use via `getMaxUses`; safer `onInvitationUsed`. Documented `normalizeEmails`.
  - Clarified activate-invite logic: uses `getMaxUses` for finite/infinite checks; clearer session/user handling; if unauthenticated, stores token in a signed cookie with configurable `maxAge` and redirects.
  - Added `ERROR_CODES.INVITATION_NOT_CREATED` and a guard in invite creation; tests ensure infinite invites stay pending and reusable.

- **Dependencies**
  - Pinned `typescript` via pnpm catalogs (`catalog:` in root, `package`, and `docs`), added `typecheck` in `package`, updated `.vscode` to `js/ts.tsdk.path`, and refreshed workspace/lockfile with the catalog.

<sup>Written for commit c0492654f391dde33d991bd3309ca3f5bebc4235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

